### PR TITLE
ndfpack: return masked arrays if there is a Starlink BADVAL defined for the type.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,4 @@
+version 0.3 (April 2016)
+-----------------------
+	- ndfpack will now return numpy masked arrays, with the STARLINK Bad values masked out
+	- ndf.c new  'type_' gives the Starlink type of the component.

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ if have_ast:
 
 ndf = Extension('starlink.ndf',
                 define_macros        = [('MAJOR_VERSION', '0'),
-                                        ('MINOR_VERSION', '2'),
+                                        ('MINOR_VERSION', '3'),
                                         ('HAVE_AST', have_ast)],
                 undef_macros         = ['USE_NUMARRAY'],
                 include_dirs         = include_dirs,
@@ -87,7 +87,7 @@ ndf = Extension('starlink.ndf',
 
 hds = Extension('starlink.hds',
                 define_macros        = [('MAJOR_VERSION', '0'),
-                                        ('MINOR_VERSION', '2')],
+                                        ('MINOR_VERSION', '3')],
                 undef_macros         = ['USE_NUMARRAY'],
                 include_dirs         = include_dirs,
                 library_dirs         = library_dirs,
@@ -97,7 +97,7 @@ hds = Extension('starlink.hds',
                 )
 
 setup(name='starlink-pyndf',
-      version='0.2',
+      version='0.3',
       packages =['starlink','starlink.ndfpack'],
       ext_modules=[ndf,hds],
       # metadata

--- a/starlink/ndf/ndf.c
+++ b/starlink/ndf/ndf.c
@@ -1139,7 +1139,7 @@ static PyMethodDef NDF_methods[] = {
     {"open", (PyCFunction)pyndf_open, METH_VARARGS,
      "indf = ndf.open(name) -- opens an NDF file."},
 
-    {"type", (PyCFunction)pyndf_type, METH_VARARGS,
+    {"type_", (PyCFunction)pyndf_type, METH_VARARGS,
      "startype = indf.read(comp) -- get the Starlink type of component comp of an NDF. Returns None if it does not exist, or a string if it does."},
 
     {"read", (PyCFunction)pyndf_read, METH_VARARGS,

--- a/starlink/ndfpack/ndf.py
+++ b/starlink/ndfpack/ndf.py
@@ -70,16 +70,31 @@ class Ndf(object):
             indf = ndf.open(fname)
             #: the data array, a numpy N-d array
             data  = indf.read('Dat')
-            badpixelvalue = ndf.ndf_getbadpixval(indf.type('Dat'))
-            self.data = ma.masked_where(data==badpixelvalue, data)
-            # Create the mask from that data.
-            #: pixel limits of data array.
+            type_ = indf.type_('Dat')
+            if type_:
+                badpixelvalue = ndf.ndf_getbadpixval(type_)
+            else:
+                badpixelvalue = None
+            if badpixelvalue:
+                self.data = ma.masked_where(data==badpixelvalue, data)
+            else:
+                self.data = data
+
+                #: pixel limits of data array.
             #: 2xndim array of lower and upper bounds
             self.bound = indf.bound()
+
             #: variances, a numpy N-d array
             var   = indf.read('Var')
-            badpixelvalue = ndf.ndf_getbadpixval(indf.type('Var'))
-            self.var = ma.masked_where(var==badpixelvalue, var)
+            type_ = indf.type_('Var')
+            if type_:
+                badpixelvalue = ndf.ndf_getbadpixval(type_)
+            else:
+                badpixelvalue = None
+            if badpixelvalue:
+                    self.var = ma.masked_where(var==badpixelvalue, var)
+            else:
+                self.var = var
 
             #: label string associated with the data
             self.label = indf.label

--- a/starlink/ndfpack/ndf.py
+++ b/starlink/ndfpack/ndf.py
@@ -4,7 +4,7 @@ from starlink.ndfpack.axis import Axis
 
 import re
 import numpy as n
-
+from numpy import ma
 
 class Ndf(object):
     """
@@ -69,12 +69,18 @@ class Ndf(object):
         try:
             indf = ndf.open(fname)
             #: the data array, a numpy N-d array
-            self.data  = indf.read('Dat')
+            data  = indf.read('Dat')
+            badpixelvalue = ndf.ndf_getbadpixval(indf.type('Dat'))
+            self.data = ma.masked_where(data==badpixelvalue, data)
+            # Create the mask from that data.
             #: pixel limits of data array.
             #: 2xndim array of lower and upper bounds
             self.bound = indf.bound()
             #: variances, a numpy N-d array
-            self.var   = indf.read('Var')
+            var   = indf.read('Var')
+            badpixelvalue = ndf.ndf_getbadpixval(indf.type('Var'))
+            self.var = ma.masked_where(var==badpixelvalue, var)
+
             #: label string associated with the data
             self.label = indf.label
             #: title string associated with the data
@@ -130,7 +136,16 @@ def _read_hds(loc, head, array=False):
                 _read_hds(loc1, h, array)
                 loc1.annul()
     elif loc.state:
-        head[name] = loc.get()
+        # If it is not a structure
+        results = loc.get()
+        if isinstance(results, n.ndarray):
+            startype = loc.type
+            try:
+                badval = ndf.ndf_getbadpixval(startype)
+                results = ma.masked_where(results==badval, results)
+            except SystemError:
+                pass
+        head[name] = results
 
 def _create_md_struc(dims):
     """Creates a multi-dimensional list of dictionaries to represent multi-dimensional structures"""


### PR DESCRIPTION
In the current version of ndfpack, bad pixel vals in all arrays (data, var, and other extensions) are left as the Starlink bad pixel value for the datatype of the array. This requires the user to find out the BAD pixel value of their data type and filter the array themselves before they can perform most analysis tasks.

These commits instead:
a) add a function to ndf.c to get the Starlink type of a component (this was done by reusing code in the read function, so this may not have been the optimal way to implement this.)

b) alters the ndfpack.py NDF class init to return numpy masked arrays if the Starlink badvalue exists for the data type. The data, var and extension components are all affected by this.
